### PR TITLE
Change symbol lookup

### DIFF
--- a/src/assembler/auxiliary.h
+++ b/src/assembler/auxiliary.h
@@ -44,6 +44,28 @@ unsigned get_length(const InstructionPtr &instruction);
 template<typename ExceptionType = std::logic_error>
 void throw_exception_and_highlight(const std::string &code, const size_t lineNumber, const size_t columnNumber, const std::string &errorMessage, const size_t highlightWidth = 1);
 
+
+/**
+ * Throws an error containing a string, in which an @p errorMessage is displayed and
+ * a certain section of the code's line is highlighted.
+ * @throws @p ExceptionType
+ *
+ * @tparam ExceptionType type of exception which is thrown
+ * @param code Source code which is highlighted
+ * @param lineNumber number of line in which the marking takes place
+ * @param columnNumber column position in which the highlighting starts
+ * @param referenceLineNumber number of line in which the marking of the reference takes place
+ * @param referenceColumnNumber column position in which the reference highlighting starts
+ * @param errorMessage an error message printed before the highlighted line
+ * @param highlightWidth the width of the highlighting starting from the position @p columnNumber
+ * @param referenceHighlightWidth the width of the reference highlighting starting from the position @p referenceColumnNumber
+ */
+template<typename ExceptionType = std::logic_error>
+void throw_exception_and_highlight_with_reference(const std::string &code, const size_t lineNumber,
+                                                  const size_t columnNumber, const size_t referenceLineNumber,
+                                                  const size_t referenceColumnNumber, const std::string &errorMessage,
+                                                  const size_t highlightWidth, const size_t referenceHighlightWidth);
+
 /**
  * Checks whether a @p character is either '+' or '-'.
  * @param character character

--- a/src/assembler/auxiliary.hpp
+++ b/src/assembler/auxiliary.hpp
@@ -18,12 +18,25 @@ std::string to_string(const std::vector<T> &vector) {
 }
 
 template<typename ExceptionType>
-void throw_exception_and_highlight(const std::string& code, const size_t lineNumber, const size_t columnNumber, const std::string &errorMessage, const size_t highlightWidth)
-{
+void throw_exception_and_highlight(const std::string &code, const size_t lineNumber, const size_t columnNumber,
+                                   const std::string &errorMessage, const size_t highlightWidth) {
     std::string extendedString = errorMessage + " at " + get_position_string(lineNumber, columnNumber) + '\n';
-    if (!code.empty())
-    {
+    if (!code.empty()) {
         extendedString += to_string_line_and_highlight(code, lineNumber, columnNumber, highlightWidth);
+    }
+    throw ExceptionType(extendedString);
+}
+
+template<typename ExceptionType>
+void throw_exception_and_highlight_with_reference(const std::string &code, const size_t lineNumber,
+                                                  const size_t columnNumber, const size_t referenceLineNumber,
+                                                  const size_t referenceColumnNumber, const std::string &errorMessage,
+                                                  const size_t highlightWidth, const size_t referenceHighlightWidth) {
+    std::string extendedString = errorMessage + " at " + get_position_string(lineNumber, columnNumber) + '\n';
+    if (!code.empty()) {
+        extendedString += to_string_line_and_highlight(code, lineNumber, columnNumber, highlightWidth);
+        extendedString += "The expression is referring to\n";
+        extendedString += to_string_line_and_highlight(code, referenceLineNumber, referenceColumnNumber, referenceHighlightWidth);
     }
     throw ExceptionType(extendedString);
 }

--- a/src/assembler/parser.cpp
+++ b/src/assembler/parser.cpp
@@ -100,8 +100,6 @@ long Parser::to_number(const Token &numToken) const {
 long Parser::to_number_conditional(const Token &numToken, const std::function<bool(long)> &condition, const std::string &errorStr) const {
     long tokenNumber = to_number(numToken);
 
-
-
     if (!condition(tokenNumber)) {
         // Get the reference token (e.g. a global or local label, or a constant) if present
         Token referenceToken;

--- a/src/assembler/parser.cpp
+++ b/src/assembler/parser.cpp
@@ -72,6 +72,12 @@ void Parser::throw_logic_error_and_highlight(const Token &token, const std::stri
                                     token.get_string().size());
 }
 
+void Parser::throw_logic_error_and_highlight_with_reference(const Token &token, const Token &referenceToken, const std::string &errorMessage) const {
+    ::throw_exception_and_highlight_with_reference(get_code(), token.get_line(), token.get_column(),
+                                                   referenceToken.get_line(), referenceToken.get_column(),
+                                                   errorMessage, token.get_string().size(), referenceToken.get_string().size());
+}
+
 void Parser::throw_invalid_argument_and_highlight(const Token &token, const std::string &errorMessage) const {
     ::throw_exception_and_highlight<std::invalid_argument>(get_code(), token.get_line(), token.get_column(), errorMessage,
                                                            token.get_string().size());
@@ -82,7 +88,7 @@ long Parser::to_number(const Token &numToken) const {
         if (numToken.has_numeric_value()) {
             return numToken.get_numeric();
         } else {
-            return symbol_lookup(numToken);
+            return symbol_lookup(numToken).get_numeric();
         }
     } catch (...) {
         throw_invalid_argument_and_highlight(numToken,
@@ -93,9 +99,27 @@ long Parser::to_number(const Token &numToken) const {
 
 long Parser::to_number_conditional(const Token &numToken, const std::function<bool(long)> &condition, const std::string &errorStr) const {
     long tokenNumber = to_number(numToken);
+
+
+
     if (!condition(tokenNumber)) {
-        throw_logic_error_and_highlight(numToken,
-                                        "Parse error: Number " + std::to_string(tokenNumber) + " is expected to be " + errorStr);
+        // Get the reference token (e.g. a global or local label, or a constant) if present
+        Token referenceToken;
+        try {
+            referenceToken = symbol_lookup(numToken).get_token();
+        } catch (...) {
+            referenceToken = Token{};
+        }
+
+        if (referenceToken.is_invalid()) {
+            throw_logic_error_and_highlight(numToken,
+                                            "Parse error: Number " + std::to_string(tokenNumber) +
+                                            " is expected to be " + errorStr);
+        } else {
+            throw_logic_error_and_highlight_with_reference(numToken, referenceToken,
+                                                           "Parse error: Number " + std::to_string(tokenNumber) +
+                                                           " is expected to be " + errorStr);
+        }
     }
     return tokenNumber;
 }

--- a/src/assembler/parser.h
+++ b/src/assembler/parser.h
@@ -68,11 +68,10 @@ private:
      * @param token token to look up in the symbolic table
      * @return the numeric value associated with the token
      */
-    long symbol_lookup(const Token &token) const
+    NumericFromToken symbol_lookup(const Token &token) const
     {
-        // TODO: change return type from long to NumericFromToken
         try {
-            return _symbolicTable.at(token.get_string()).get_numeric();
+            return _symbolicTable.at(token.get_string());
         } catch (...) {
             throw_logic_error_and_highlight(token, "Parse error: Using the symbol \"" + token.get_string() + "\" which has not been assigned yet");
         }
@@ -364,6 +363,15 @@ private:
      * @param errorMessage an error message printed before the highlighted line
      */
     void throw_logic_error_and_highlight(const Token &token, const std::string &errorMessage) const;
+
+    /**
+     * Throws a logic error exception containing a string, in which the token is highlighted.
+     * Additionally, the token @p referenceToken which is referenced by @p token is mentioned in the error message.
+     * @throws std::logic_error
+     * @param token the token to highlight
+     * @param errorMessage an error message printed before the highlighted line
+     */
+    void throw_logic_error_and_highlight_with_reference(const Token &token, const Token &referenceToken, const std::string &errorMessage) const;
 
     /**
      * Throws an invalid argument exception containing a string, in which the token is highlighted.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,7 @@ int main()
     std::string code(
                      "CONSTANT1 EQU 1\n"
                      "CONSTANT2 EQU 2\n"
+                     "CONSTANT3 EQU 0xFFFFF\n"
                      "LABEL1:\n"
                      "DEC HL\n"
                      "JP LABEL1\n"
@@ -123,6 +124,8 @@ int main()
                      "ADD A, CONSTANT2\n"
                      "END:\n"
                      "ADC 0x99\n"
+                     //"ADC 0xFFFFF\n"
+                     "ADC CONSTANT3\n"
                      "LD A, CONSTANT1\n"
                      "LD HL, SP+0x11\n"
                      );


### PR DESCRIPTION
In order to allow for more expressive error messages of the parser, the symbol table now contains not only the symbol's number but also its original token. Whenever an error is thrown because of a label or constant, the reference label is now also stated in the error message.