### PR TITLE
Adapt jr parse to differentiate labels and constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # gameboy-decode
 Decoder for gameboy bytecode. Work in progress.
 
+- [x] Supports "EQU" definitions of constants
+- [x] Supports global labels
 - [x] Supports local labels
-
-Never use `JR ` with assembler-specific constants. Only labels, since the symbolic table saves each entry exactly once
-and hence it will be treated as label (and calculating the difference).

--- a/src/assembler/auxiliary.hpp
+++ b/src/assembler/auxiliary.hpp
@@ -35,7 +35,7 @@ void throw_exception_and_highlight_with_reference(const std::string &code, const
     std::string extendedString = errorMessage + " at " + get_position_string(lineNumber, columnNumber) + '\n';
     if (!code.empty()) {
         extendedString += to_string_line_and_highlight(code, lineNumber, columnNumber, highlightWidth);
-        extendedString += "The expression is referring to\n";
+        extendedString += "This expression is referring to\n";
         extendedString += to_string_line_and_highlight(code, referenceLineNumber, referenceColumnNumber, referenceHighlightWidth);
     }
     throw ExceptionType(extendedString);

--- a/src/assembler/parser.cpp
+++ b/src/assembler/parser.cpp
@@ -156,7 +156,7 @@ byte Parser::to_relative_offset(const Token &positionToken, const size_t referen
 
     if (!(is_signed_8_bit(offset))) {
         const std::string errorMessage = "Parse error: The goal \"" + positionToken.get_string() +
-                                         "\" is too far away from the current line. Please use JP instead of JR";
+                                         "\" results in a jump of " + to_string_hex_signed_prefixed(offset) + ", which is not a signed 8-bit number. Please use JP instead of JR";
         if (referenceType == TokenType::INVALID) { // token contains no reference
             throw_logic_error_and_highlight(positionToken, errorMessage);
         } else {

--- a/src/assembler/parser.cpp
+++ b/src/assembler/parser.cpp
@@ -139,11 +139,29 @@ long Parser::to_unsigned_number_16_bit(const Token &numToken) const {
 
 byte Parser::to_relative_offset(const Token &positionToken, const size_t referenceAddress) const
 {
-    long tokenPosition = to_unsigned_number_16_bit(positionToken);
-    long offset = tokenPosition - referenceAddress;
+    long tokenValue = to_unsigned_number_16_bit(positionToken);
+
+    // In case the positionToken is referring to a label, we must treat it differently
+    const Token referenceToken = determine_reference_token(positionToken);
+    const TokenType referenceType = referenceToken.get_token_type();
+
+    long offset;
+    if (referenceType == TokenType::LOCAL_LABEL || referenceType == TokenType::GLOBAL_LABEL) {
+        // the offset is determined by the number of words between the referenceAddress and the label's address
+        offset = tokenValue - referenceAddress;
+    } else {
+        // otherwise it is the plain numeric value of the token
+        offset = tokenValue;
+    }
+
     if (!(is_signed_8_bit(offset))) {
-        throw_logic_error_and_highlight(positionToken,
-                                        "Parse error: The goal " + positionToken.get_string() + " is too far away from the current line. Please use JP instead of JR");
+        const std::string errorMessage = "Parse error: The goal \"" + positionToken.get_string() +
+                                         "\" is too far away from the current line. Please use JP instead of JR";
+        if (referenceType == TokenType::INVALID) { // token contains no reference
+            throw_logic_error_and_highlight(positionToken, errorMessage);
+        } else {
+            throw_logic_error_and_highlight_with_reference(positionToken, referenceToken, errorMessage);
+        }
     }
     return offset;
 }

--- a/src/assembler/parser.cpp
+++ b/src/assembler/parser.cpp
@@ -102,12 +102,7 @@ long Parser::to_number_conditional(const Token &numToken, const std::function<bo
 
     if (!condition(tokenNumber)) {
         // Get the reference token (e.g. a global or local label, or a constant) if present
-        Token referenceToken;
-        try {
-            referenceToken = symbol_lookup(numToken).get_token();
-        } catch (...) {
-            referenceToken = Token{};
-        }
+        const Token referenceToken = determine_reference_token(numToken);
 
         if (referenceToken.is_invalid()) {
             throw_logic_error_and_highlight(numToken,

--- a/src/assembler/parser.h
+++ b/src/assembler/parser.h
@@ -80,6 +80,9 @@ private:
     /**
      * Determines and returns the token which is referred to by @p token.
      * The type is determined by the token which is used for lookup of @p token's string in the symbol table.
+     * In case the symbol does not refer to something in the symbol table (e.g. numeral constants like 0x1234),
+     * an empty token of TokenType::INVALID is returned.
+     *
      * This is e.g. used for the relative jump "JR GOAL", since it must determine whether GOAL is a constant or
      * a label, since for labels the calculation involves calculating the offset.
      *

--- a/src/assembler/parser.h
+++ b/src/assembler/parser.h
@@ -78,6 +78,41 @@ private:
     }
 
     /**
+     * Determines and returns the token which is referred to by @p token.
+     * The type is determined by the token which is used for lookup of @p token's string in the symbol table.
+     * This is e.g. used for the relative jump "JR GOAL", since it must determine whether GOAL is a constant or
+     * a label, since for labels the calculation involves calculating the offset.
+     *
+     * See the following table for some further examples:
+     *      Assume that we have assembly code:
+     *          1 | CONSTANT EQU 0xBEEF
+     *          2 | LABEL:
+     *          3 |    NOP
+     *          4 | .LOCAL
+     *          5 |    JR 0x1234
+     *          6 |    JR CONSTANT
+     *          7 |    JR LABEL
+     *          8 |    JR .LOCAL
+     *      0x1234    -> TokenType::INVALID (since it is a constant numeral and not referring to anything in the symbol table)
+     *      CONSTANT  -> referring to the first token with TokenType::IDENTIFIER in line 1
+     *      LABEL     -> referring to the label with TokenType::GLOBAL_LABEL in line 2
+     *      .LOCAL    -> referring to the label with TokenType::LOCAL_LABEL in line 4
+     *
+     * @param token the token whose reference type is determined
+     * @return the token which is referred to by @p token
+     */
+    Token determine_reference_token(const Token &token) const {
+        Token referenceToken;
+        try {
+            referenceToken = symbol_lookup(token).get_token();
+        } catch (...) {
+            referenceToken = Token{};
+        }
+
+        return referenceToken;
+    }
+
+    /**
      * Takes a vector of UnresolvedInstructionPtr, resolves them and returns the vector of resolved instructions
      * @param unresolvedInstructions Vector of unresolved instructions
      * @return vector containing resolved instructions

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,8 @@ int main()
                      "END:\n"
                      "ADC 0x99\n"
                      //"ADC 0xFFFFF\n"
-                     "ADC CONSTANT3\n"
+                     //"ADC CONSTANT3\n"
+                     "JR CONSTANT3\n"
                      "LD A, CONSTANT1\n"
                      "LD HL, SP+0x11\n"
                      );

--- a/tests/tests_assembler_parser_instructions/jump.hpp
+++ b/tests/tests_assembler_parser_instructions/jump.hpp
@@ -303,6 +303,27 @@ TEST_CASE("'JR' commands are parsed correctly", "[Parser::parse]") {
         REQUIRE(currentInstruction == correctInstruction);
     }
 
+    SECTION("JR to constant jump declared before") {
+        TokenVector tokenVector {
+                {1, 1, TokenType::IDENTIFIER, "CONSTANT"},
+                {1, 1, TokenType::IDENTIFIER, "EQU"},
+                {1, 1, TokenType::NUMBER, "0x7F"},
+                {1, 1, TokenType::END_OF_LINE, "\\n"},
+
+                {1, 1, TokenType::IDENTIFIER, "JR"},
+                {1, 1, TokenType::IDENTIFIER, "CONSTANT"},
+                {1, 1, TokenType::END_OF_FILE, "[EOF]"}
+        };
+        Parser parser("", tokenVector);
+        InstructionVector instructionVector = parser.parse();
+
+        REQUIRE(instructionVector.size() == 1);
+
+        const BaseInstruction currentInstruction = *instructionVector[0];
+        const BaseInstruction correctInstruction = JumpRelative(0x7F);
+        REQUIRE(currentInstruction == correctInstruction);
+    }
+
     SECTION("JR throws an error if goal label is too far away") {
         TokenVector tokenVector {
                 {1, 1, TokenType::GLOBAL_LABEL, "LABEL1:"},


### PR DESCRIPTION
Until now, assembly command `JR` supported labels only as operand. Now, it also supports `EQU` constants correctly.